### PR TITLE
Remove cxxflags_save hack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,9 +7,7 @@ AC_CONFIG_SRCDIR([modigliani.lsm])
 AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
-cxxflags_save="$CXXFLAGS"
 AC_PROG_CXX
-CXXFLAGS="$cxxflags_save"
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_LEX


### PR DESCRIPTION
This construct causes the compilation of Modigliani without any CXXFLAGS
if none are defined by the user, instead of the default -g -O2.
